### PR TITLE
Make `cluster-name` argument from Kube-controller-manager daemon a job property

### DIFF
--- a/jobs/kube-controller-manager/spec
+++ b/jobs/kube-controller-manager/spec
@@ -31,6 +31,9 @@ properties:
     description: "The duration that specifies how long the autoscaler has to wait before another upscale operation"
   horizontal-pod-autoscaler.use-rest-clients:
     description: "If true, horizontal pod autoscaler controller will use REST clients through the kube-aggregator, instead of using the legacy metrics client through the API server proxy"
+  cluster-name:
+    description: Kubernetes cluster name
+    default: kubernetes
   http_proxy:
     description: http_proxy env var for the kubernetes-controller-manager binary (i.e. for cloud provider interactions)
   https_proxy:

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -7,7 +7,7 @@ processes:
   - --cloud-provider=<%= cloud_provider.p('cloud-provider.type') %>
   - --cloud-config=/var/vcap/jobs/kube-controller-manager/config/cloud-provider.ini
   <%- end -%>
-  - --cluster-name=kubernetes
+  - --cluster-name=<%=p('cluster-name') %>
   - --cluster-signing-cert-file=/var/vcap/jobs/kube-controller-manager/config/cluster-signing-ca.pem
   - --cluster-signing-key-file=/var/vcap/jobs/kube-controller-manager/config/cluster-signing-key.pem
   <%- if_p('horizontal-pod-autoscaler.downscale-delay') do |delay| -%>


### PR DESCRIPTION
Herllo,
I just created this PR: https://github.com/cloudfoundry-incubator/kubo-release/pull/248
I thought, you will need it.